### PR TITLE
Update wan2skeaf.jl

### DIFF
--- a/aiida_skeaf/calculations/wan2skeaf.py
+++ b/aiida_skeaf/calculations/wan2skeaf.py
@@ -142,6 +142,8 @@ class Wan2skeafCalculation(CalcJob):
             cmdline_params += ["-p", parameters["occupation_prefactor"]]
         if "tol_n_electrons" in parameters:
             cmdline_params += ["-t", parameters["tol_n_electrons"]]
+        if "fermi_energy" in parameters:
+            cmdline_params += ["-f", parameters["fermi_energy"]]
 
         cmdline_params.append(self.inputs.bxsf_filename.value)
         #
@@ -190,6 +192,7 @@ input_parameters = {
     Optional("smearing_value"): float,
     Optional("occupation_prefactor"): int,
     Optional("tol_n_electrons"): float,
+    Optional("fermi_energy"): float,
 }
 
 

--- a/aiida_skeaf/parsers/wan2skeaf.py
+++ b/aiida_skeaf/parsers/wan2skeaf.py
@@ -196,7 +196,7 @@ def parse_wan2skeaf_out(filecontent: ty.List[str]) -> orm.Dict:
             r"Custom Fermi energy  will be used to select the bands "
             + r"that are written to separate bxsfs:\s*([+-]?(?:[0-9]*[.])?[0-9]+)"
         ),
-        "bands_crossing_fermi": re.compile(r"Bands crossing Fermi energy:\s*(.+)"),
+        "bands_crossing_fermi": re.compile(r"Bands crossing Fermi energy:\s*(.*)"),
         "timestamp_end": re.compile(r"Job done at\s*(.+)"),
     }
     re_band_minmax = re.compile(

--- a/utils/wan2skeaf.jl/wan2skeaf.jl
+++ b/utils/wan2skeaf.jl/wan2skeaf.jl
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S julia --project=/home/paulis_n/Software/aiida-fermisurface/code/aiida-skeaf/utils/wan2skeaf.jl
+#!/usr/bin/env -S julia --project=/home/aiida/envs/aiida-fermisurf/code/aiida-skeaf/utils/wan2skeaf.jl
 #
 # To use this script, one need to frist instantiate the julia environment, by running
 #   julia --project=.
@@ -172,7 +172,6 @@ The script
     println("Bands in bxsf: ", join([string(_) for _ in band_range], " "))
     bands_crossing_fermi = zeros(Int,0)
     for ib in band_range
-        # here I am still using the Fermi energy from input bxsf, i.e., QE scf Fermi
         outfile = out_filename * "_band_$(ib).bxsf"
         band_min = minimum(bxsf.E[ib:ib, :, :, :])
         band_max = maximum(bxsf.E[ib:ib, :, :, :])
@@ -184,7 +183,7 @@ The script
         if (ϵF >= band_min && ϵF <= band_max)
             push!(bands_crossing_fermi, ib)
             E_band_Ry = bxsf.E[ib:ib, :, :, :].*(ELECTRONVOLT_SI/RYDBERG_SI)
-            E_fermi_Ry = bxsf.fermi_energy*(ELECTRONVOLT_SI/RYDBERG_SI)
+            E_fermi_Ry = E_fermi_Ry = ϵF*(ELECTRONVOLT_SI/RYDBERG_SI)
             span_vectors_bohr = bxsf.span_vectors.*BOHR_TO_ANG/2/pi
             # what about the origin? It has to be zero (Gamma point) for bxsf so I don't change it here
             WannierIO.write_bxsf(outfile, E_fermi_Ry, bxsf.origin, span_vectors_bohr, E_band_Ry)


### PR DESCRIPTION
**Store only needed one band bxsfs**
  * In wan2skeaf.jl write bxsfs only for bands that cross Fermi energy (FE)
  * The workflow stores only the needed bxsfs as output RemoteData nodes
  * Allow passing a custom Fermi energy to wan2skeaf.jl
  * New parameter `fermi_energy` to workchain.inputs.wan2skeaf
  * Modify `validate_inputs` function of the SkeafWorkChain to check that `fermi_energy` is passed correctly
      - if FE is specified only in skeaf parameters, it is passed also to wan2skeaf parameters
      - error if FE specified only in wan2skeaf or values in skeaf and wan2skeaf parameters are different
  * New entries `custom_fermi_energy` and `bands_crossing_fermi` in wan2skeaf.outputs.output_parameters
  * Set default for `fermi_energy` parameter in wan2skeaf.jl to "none"
 
**Fix bug in wan2skeaf in case no bands cross Fermi**